### PR TITLE
Add libarchive.so.13 to search list for running in Debian and Ubuntu

### DIFF
--- a/lib/archive_io/lib_archive.rb
+++ b/lib/archive_io/lib_archive.rb
@@ -7,7 +7,7 @@ module ArchiveIO
     OK = 0
     EOF = 1
 
-    ffi_lib ["archive", "libarchive.so.2"]
+    ffi_lib ["archive", "libarchive.so.2", "libarchive.so.13"]
 
     attach_function :archive_version_string, [], :string
     attach_function :archive_read_open_filename, [:pointer, :string, :size_t], :int


### PR DESCRIPTION
In Debian 8 (jessie) and Ubuntu starting at least from 14.04 (trusty) package is named `libarchive13` and contains only `libarchive.so.13` symlink and doesn't contains just `libarchive.so`.

See http://packages.ubuntu.com/xenial-updates/libarchive13 for details.

Possible workaround:

```sh
ln -s /usr/lib/x86_64-linux-gnu/libarchive.so{.13,}
```